### PR TITLE
Features/libev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,12 +5,28 @@ This is the base package for caliopen platform.
 
 It contains following sub packages:
 
-- store : All classes related to datastore.
-          Base model User and Contact are included.
+    store 
+        All classes related to datastore.
+        Base model User and Contact are included.
 
-- core : Classes where business logic must be define.
-         Datastores objects are not directly managed,
-         they must have a related core class to act as
-         an interface with others caliopen components.
+    core
+        Classes where business logic must be define.
+        Datastores objects are not directly managed,
+        they must have a related core class to act as
+        an interface with others caliopen components.
 
-- helpers : Some common helpers for all caliopen parts.
+    helpers
+        Some common helpers for all caliopen parts.
+
+
+Notes
+-----
+
+waitress and cassandra driver conflict
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cassandra python driver use async_core by default and can
+conflict with waitress event loop (1). It is advocated to install
+libev on your system to avoid this problem (2).
+
+(1) https://github.com/Pylons/waitress/issues/63
+(2) http://datastax.github.io/python-driver/installation.html#c-extensions

--- a/caliopen/base/helpers/connection.py
+++ b/caliopen/base/helpers/connection.py
@@ -7,6 +7,13 @@ from caliopen.base.config import Configuration
 
 def connect_storage():
     """Connect to storage engines."""
+    try:
+        from cassandra.io.libevreactor import LibevConnection
+        kwargs = {'connection_class': LibevConnection}
+    except ImportError:
+        kwargs = {}
     setup_cassandra(Configuration('global').get('cassandra.hosts'),
                     Configuration('global').get('cassandra.keyspace'),
-                    Configuration('global').get('cassandra.consistency_level'))
+                    Configuration('global').get('cassandra.consistency_level'),
+                    lazy_connect=True,
+                    **kwargs)


### PR DESCRIPTION
on development platform there is a conflict on async_core event loop between waitress and cassandra driver.

Use of libev if installed solve this problem as noted in this issue : https://github.com/Pylons/waitress/issues/63

This branch permit to use such connection class when setup cassandra session if libev is available on the system.

BTW use of lazy_connect on cassandra connection setup is really useful.