### PR TITLE
fix depreciate cqlengine

### DIFF
--- a/caliopen/base/helpers/connection.py
+++ b/caliopen/base/helpers/connection.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Caliopen storage session helpers."""
 
-from cqlengine.connection import setup as setup_cassandra
+from cassandra.cqlengine.connection import setup as setup_cassandra
 from caliopen.base.config import Configuration
 
 

--- a/caliopen/base/store/model.py
+++ b/caliopen/base/store/model.py
@@ -2,8 +2,8 @@
 """Caliopen cassandra base model classes."""
 import logging
 
-from cqlengine.models import Model
-from cqlengine.query import DoesNotExist
+from cassandra.cqlengine.models import Model
+from cassandra.cqlengine.query import DoesNotExist
 
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = [
     'bcrypt',
     'PyYAML',
     'elasticsearch-dsl',
-    'cqlengine',
+    'cassandra-driver',
     'schematics',
     'simplejson',
     ]


### PR DESCRIPTION
'cqlengine' is a depreciate package. Use 'cassandra.cqlengine'.

this old package is not compatible with the current cassandra version (3.1.1).
Error with [sync_table](https://github.com/CaliOpen/caliopen.cli/blob/0cdc7589c9c41
8d744a540ca20f0a0e57c74c665/caliopen/cli/commands/setup_storage.py#L24) (used by ./load-fixtures) :
```
code=2200 [Invalid query] message="unconfigured table schema_keyspaces"
```

"system.schema_keyspaces" have been renamed to "system_shema.keyspaces"